### PR TITLE
Enable renovate for cloudflared

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,5 +12,44 @@ on:
 
 jobs:
   build:
-    name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v24
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up environment
+        run: |
+          sudo adduser "$USER" lxd
+          # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxd waitready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxd init --auto
+          # Workaround for Docker & LXD on same machine
+          sudo iptables -F FORWARD
+          sudo iptables -P FORWARD ACCEPT
+
+          sudo snap install snapcraft --classic ${{ steps.snapcraft-snap-version.outputs.install_flag }}
+      - name: Pack snap
+        run: sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- snapcraft pack -v
+      - name: Snapcraft logs
+        if: ${{ success() || (failure() && steps.pack.outcome == 'failure') }}
+        run: cat ~/.local/state/snapcraft/log/*
+      - run: touch .empty
+      - name: Compute path in artifact
+        id: path-in-artifact
+        run: compute-path-in-artifact '${{ inputs.path-to-snap-project-directory }}'
+      - name: Upload snap package
+        uses: actions/upload-artifact@v4
+        with:
+          name: charmed-cloudflared.snap
+          path: "*.snap"
+          if-no-files-found: error
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: pip install pytest requests
+      - name: Run tests
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: pytest tests -v --tb native -rP --log-cli-level=DEBUG --snap-file=./charmed-cloudflared_*.snap

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,4 +50,5 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           export SNAP_FILE=$(ls charmed-cloudflared_*.snap)
+          sudo snap set system experimental.parallel-instances=true
           pytest tests -v --tb native -rP --log-cli-level=DEBUG --snap-file=./$SNAP_FILE

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,4 +48,6 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: pytest tests -v --tb native -rP --log-cli-level=DEBUG --snap-file=./charmed-cloudflared_*.snap
+        run: |
+          export SNAP_FILE=$(ls charmed-cloudflared_*.snap)
+          pytest tests -v --tb native -rP --log-cli-level=DEBUG --snap-file=./$SNAP_FILE

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,10 +32,6 @@ jobs:
       - name: Snapcraft logs
         if: ${{ success() || (failure() && steps.pack.outcome == 'failure') }}
         run: cat ~/.local/state/snapcraft/log/*
-      - run: touch .empty
-      - name: Compute path in artifact
-        id: path-in-artifact
-        run: compute-path-in-artifact '${{ inputs.path-to-snap-project-directory }}'
       - name: Upload snap package
         uses: actions/upload-artifact@v4
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "group:all"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^snap/snapcraft\\.yaml$"
+      ],
+      "matchStrings": [
+        "version: &cloudflared-version (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "cloudflare/cloudflared"
+    }
   ]
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,12 +36,15 @@ apps:
 parts:
   cfgo:
     plugin: nil
-    source: https://github.com/cloudflare/go.git
+    source: https://github.com/cloudflare/cloudflared.git
     source-type: git
-    source-commit: ec0a014545f180b0c74dfd687698657a9e86e310
+    source-tag: *cloudflared-version
     build-snaps: [ go ]
     override-build: |
-      cd ./src
+      CFGO_REF=$(grep -Po '(?<=git checkout -q )[0-9a-f]+' .teamcity/install-cloudflare-go.sh)
+      git clone https://github.com/cloudflare/go
+      cd go/src
+      git checkout $CFGO_REF
       ./make.bash
   cloudflared:
     plugin: nil
@@ -52,11 +55,8 @@ parts:
     build-environment:
       - GO111MODULE: "on"
       - CGO_ENABLED: "0"
-    override-build: |
-      # match source-commit in the cfgo part
-      grep -q ec0a014545f180b0c74dfd687698657a9e86e310 .teamcity/install-cloudflare-go.sh
-      
-      export PATH="$(realpath $CRAFT_PART_BUILD/../../cfgo/build/bin):$PATH"
+    override-build: |      
+      export PATH="$(realpath $CRAFT_PART_BUILD/../../cfgo/build/go/bin):$PATH"
       which go | grep cfgo
       make cloudflared
       mkdir -p $CRAFT_PART_INSTALL/usr/bin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: charmed-cloudflared
 base: core24
+# don't change the following line, it's necessary for renovate!
 version: &cloudflared-version 2024.9.1
 summary: Cloudflared in a snap.
 description: >-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,163 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Fixtures for snap tests."""
+
+import datetime
+import logging
+import os
+import random
+import string
+import subprocess
+from typing import Generator
+
+import pytest
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def pytest_addoption(parser):
+    """Parse additional pytest options.
+
+    Args:
+        parser: Pytest parser.
+    """
+    parser.addoption("--snap-file", action="store", required=True)
+
+
+def exec(cmd: list[str], redact: str = None):
+    command_line = " ".join(cmd)
+    if redact:
+        command_line = command_line.replace(redact, "***")
+    logger.info(f"executing command: {command_line}")
+    return subprocess.check_call(cmd)
+
+
+@pytest.fixture(scope="module", name="charmed_cloudflared_snap")
+def install_charmed_cloudflared_snap(pytestconfig) -> Generator[str, None, None]:
+    snap_file = pytestconfig.getoption("--snap-file")
+    nonce = "".join(random.choice(string.ascii_lowercase) for _ in range(4))
+    name = f"charmed-cloudflared_test{nonce}"
+    exec(["sudo", "snap", "install", "--dangerous", "--name", name, snap_file])
+
+    yield name
+
+    exec(["sudo", "snap", "remove", name, "--purge"])
+
+
+class CloudflareAPI:
+    """Cloudflare API."""
+
+    def __init__(self, account_id, api_token) -> None:
+        """Initialize the Cloudflare API.
+
+        Args:
+            account_id: cloudflare account ID.
+            api_token: cloudflare API token.
+        """
+        self._endpoint = (
+            f"https://api.cloudflare.com/client/v4/accounts/{account_id}/cfd_tunnel"
+        )
+        self._session = requests.Session()
+        self._session.headers.update(
+            {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+        )
+        self._created_tunnels: list[str] = []
+        self._tunnel_token_lookup: dict[str, str] = {}
+
+    def _create_tunnel(self) -> str:
+        """Create a Tunnel.
+
+        Returns:
+            Cloudflare tunnel ID.
+        """
+        name = datetime.datetime.now().strftime("%Y%m%d-%H%M%S-")
+        name = name + "".join(random.choices(string.ascii_letters + string.digits, k=4))
+        logger.info("creating tunnel %s", name)
+        response = self._session.post(
+            self._endpoint, json={"name": name, "config_src": "cloudflare"}, timeout=10
+        )
+        response.raise_for_status()
+        tunnel_id = response.json()["result"]["id"]
+        logger.info("created tunnel %s", tunnel_id)
+        self._created_tunnels.append(tunnel_id)
+        return tunnel_id
+
+    def _get_tunnel_token(self, tunnel_id: str) -> str:
+        """Get tunnel token.
+
+        Args:
+            tunnel_id: cloudflare tunnel ID.
+
+        Returns:
+            Tunnel token.
+        """
+        response = self._session.get(f"{self._endpoint}/{tunnel_id}/token", timeout=10)
+        response.raise_for_status()
+        tunnel_token = response.json()["result"]
+        self._tunnel_token_lookup[tunnel_token] = tunnel_id
+        return tunnel_token
+
+    def create_tunnel_token(self) -> str:
+        """Create a tunnel and return its tunnel token.
+
+        Returns:
+            Tunnel token.
+        """
+        tunnel_id = self._create_tunnel()
+        return self._get_tunnel_token(tunnel_id)
+
+    def _get_tunnel_status(self, tunnel_id: str) -> str:
+        """Get tunnel status.
+
+        Args:
+            tunnel_id: cloudflare tunnel ID.
+
+        Returns:
+            Tunnel status.
+        """
+        response = self._session.get(f"{self._endpoint}/{tunnel_id}", timeout=10)
+        response.raise_for_status()
+        return response.json()["result"]["status"]
+
+    def get_tunnel_status_by_token(self, tunnel_token: str) -> str:
+        """Get tunnel status by its tunnel token.
+
+        Args:
+            tunnel_token: cloudflare tunnel token.
+
+        Returns:
+            Tunnel status.
+        """
+        tunnel_id = self._tunnel_token_lookup[tunnel_token]
+        return self._get_tunnel_status(tunnel_id)
+
+    def delete_tunnel(self, tunnel_id: str) -> None:
+        """Delete a tunnel.
+
+        Args:
+            tunnel_id: cloudflare tunnel ID.
+        """
+        logger.info("deleting tunnel %s", tunnel_id)
+        response = self._session.delete(f"{self._endpoint}/{tunnel_id}", timeout=10)
+        response.raise_for_status()
+
+
+@pytest.fixture(scope="module")
+def cloudflare_api():
+    """Cloudflare API fixture."""
+    account_id = os.environ["CLOUDFLARE_ACCOUNT_ID"]
+    assert account_id
+    api_token = os.environ["CLOUDFLARE_API_TOKEN"]
+    assert api_token
+    api = CloudflareAPI(account_id=account_id, api_token=api_token)
+
+    yield api
+
+    for tunnel_id in api._created_tunnels:
+        try:
+            logger.info("deleting tunnel %s", tunnel_id)
+            api.delete_tunnel(tunnel_id)
+        except requests.exceptions.RequestException:
+            logger.exception("failed to delete tunnel %s", tunnel_id)

--- a/tests/test_charmed_cloudflared.py
+++ b/tests/test_charmed_cloudflared.py
@@ -1,0 +1,75 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""charmed-cloudflared snap tests."""
+
+import logging
+import time
+
+from conftest import exec
+
+logger = logging.getLogger(__name__)
+
+
+def wait_for_tunnel_healthy(cloudflare_api, tunnel_token):
+    """Wait for a cloudflared tunnel to become healthy.
+
+    Args:
+        cloudflare_api: Cloudflare API object.
+        tunnel_token: Tunnel token.
+
+    Raises:
+        TimeoutError: If tunnel fails to become healthy in given timeout.
+    """
+    deadline = time.time() + 300
+    while time.time() < deadline:
+        tunnel_status = cloudflare_api.get_tunnel_status_by_token(tunnel_token)
+        logger.info("tunnel status: %s", tunnel_status)
+        if tunnel_status != "healthy":
+            time.sleep(10)
+        else:
+            return
+    raise TimeoutError("timeout waiting for tunnel healthy")
+
+
+def test_tunnel_token_config(cloudflare_api, charmed_cloudflared_snap):
+    tunnel_token = cloudflare_api.create_tunnel_token()
+    exec(
+        [
+            "sudo",
+            "snap",
+            "set",
+            charmed_cloudflared_snap,
+            f"tunnel-token={tunnel_token}",
+            "metrics-port=39000",
+        ],
+        redact=tunnel_token,
+    )
+    exec(
+        [
+            "sudo",
+            "cp",
+            "/etc/resolv.conf",
+            f"/var/snap/{charmed_cloudflared_snap}/current/etc/",
+        ]
+    )
+    exec(
+        [
+            "sudo",
+            "mkdir",
+            "-p",
+            f"/var/snap/{charmed_cloudflared_snap}/current/etc/ssl/certs",
+        ]
+    )
+    exec(
+        [
+            "sudo",
+            "cp",
+            "/etc/ssl/certs/ca-certificates.crt",
+            f"/var/snap/{charmed_cloudflared_snap}/current/etc/ssl/certs/ca-certificates.crt",
+        ]
+    )
+    exec(
+        ["sudo", "snap", "start", "--enable", f"{charmed_cloudflared_snap}.cloudflared"]
+    )
+    wait_for_tunnel_healthy(cloudflare_api, tunnel_token)


### PR DESCRIPTION
Enable Renovate for the cloudflared version inside the `snapcraft.yaml` file, and add tests to validate the snap build.