### PR TITLE
Revert HTTP proxy snap configuration

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -9,6 +9,7 @@ for config in ["metrics-port", "tunnel-token"]:
     if not subprocess.check_output(["snapctl", "get", config]).strip():
         subprocess.check_call(["snapctl", "set", f"{config}="])
 
+# fix mistakes in old revision of the snap
 for config in ["http-proxy", "https-proxy", "no-proxy"]:
     subprocess.check_call(["snapctl", "unset", config])
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -5,8 +5,11 @@
 
 import subprocess
 
-for config in ["metrics-port", "tunnel-token", "http-proxy", "https-proxy", "no-proxy"]:
+for config in ["metrics-port", "tunnel-token"]:
     if not subprocess.check_output(["snapctl", "get", config]).strip():
         subprocess.check_call(["snapctl", "set", f"{config}="])
+
+for config in ["http-proxy", "https-proxy", "no-proxy"]:
+    subprocess.check_call(["snapctl", "unset", config])
 
 subprocess.run(["snapctl", "restart", "cloudflared"])

--- a/snap/local/entrypoint.py
+++ b/snap/local/entrypoint.py
@@ -22,23 +22,6 @@ def get_metrics_port() -> int | None:
     return int(port) if port else None
 
 
-def get_proxy_env() -> dict:
-    http_proxy = get_config("http-proxy")
-    https_proxy = get_config("https-proxy")
-    no_proxy = get_config("no-proxy")
-    env = {}
-    if http_proxy:
-        env["HTTP_PROXY"] = http_proxy
-        env["http_proxy"] = http_proxy
-    if https_proxy:
-        env["HTTPS_PROXY"] = https_proxy
-        env["https_proxy"] = https_proxy
-    if no_proxy:
-        env["NO_PROXY"] = no_proxy
-        env["no_proxy"] = no_proxy
-    return env
-
-
 def main():
     os.setgroups([])
     os.setregid(584792, 584792)
@@ -58,7 +41,6 @@ def main():
                 "run",
             ],
             env={
-                **get_proxy_env(),
                 "TUNNEL_TOKEN": token,
             },
         )


### PR DESCRIPTION
Based on testing, the `cloudflared tunnel` subcommand doesn't respond to the HTTP proxy environment variable like other subcommands such as `cloudflared proxy-dns`. As the result, revert the HTTP proxy snap configurations.
