### PR TITLE
Add metrics for HTTP proxy connections

### DIFF
--- a/snap/patches/https-proxy.patch
+++ b/snap/patches/https-proxy.patch
@@ -1,8 +1,8 @@
 diff --git a/edgediscovery/dial.go b/edgediscovery/dial.go
-index 1bbf59c3..6f1f317f 100644
+index 1bbf59c3..4bdbe372 100644
 --- a/edgediscovery/dial.go
 +++ b/edgediscovery/dial.go
-@@ -1,14 +1,83 @@
+@@ -1,14 +1,218 @@
  package edgediscovery
  
  import (
@@ -10,20 +10,139 @@ index 1bbf59c3..6f1f317f 100644
  	"context"
  	"crypto/tls"
 +	"fmt"
++	"io"
  	"net"
 +	"net/http"
 +	"net/url"
 +	"os"
++	"runtime"
 +	"strconv"
++	"sync/atomic"
  	"time"
  
  	"github.com/pkg/errors"
++	"github.com/prometheus/client_golang/prometheus"
 +	"golang.org/x/net/proxy"
  )
  
++var activeProxyConnections = prometheus.NewGauge(prometheus.GaugeOpts{
++	Namespace: "cloudflared",
++	Subsystem: "dialer",
++	Name:      "active_proxy_connections",
++	Help:      "Number of currently active proxy connections.",
++})
++
++var proxyConnectionErrors = prometheus.NewCounter(prometheus.CounterOpts{
++	Namespace: "cloudflared",
++	Subsystem: "dialer",
++	Name:      "proxy_connection_errors_total",
++	Help:      "Total number of proxy connection errors.",
++})
++
++var proxyReadErrors = prometheus.NewCounter(prometheus.CounterOpts{
++	Namespace: "cloudflared",
++	Subsystem: "dialer",
++	Name:      "proxy_read_errors_total",
++	Help:      "Total number of proxy connection read errors.",
++})
++
++var proxyWriteErrors = prometheus.NewCounter(prometheus.CounterOpts{
++	Namespace: "cloudflared",
++	Subsystem: "dialer",
++	Name:      "proxy_write_errors_total",
++	Help:      "Total number of proxy connection write errors.",
++})
++
++var proxyReadBytes = prometheus.NewCounter(prometheus.CounterOpts{
++	Namespace: "cloudflared",
++	Subsystem: "dialer",
++	Name:      "proxy_read_bytes_total",
++	Help:      "Total number of bytes read from proxy connections.",
++})
++
++var proxyWriteBytes = prometheus.NewCounter(prometheus.CounterOpts{
++	Namespace: "cloudflared",
++	Subsystem: "dialer",
++	Name:      "proxy_write_bytes_total",
++	Help:      "Total number of bytes written to proxy connections.",
++})
++
++var proxyConnectionDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
++	Namespace: "cloudflared",
++	Subsystem: "dialer",
++	Name:      "proxy_connection_duration_seconds",
++	Help:      "Duration of proxy connections in seconds.",
++	Buckets:   prometheus.ExponentialBuckets(0.1, 2, 20),
++})
++
++func init() {
++	prometheus.MustRegister(
++		activeProxyConnections,
++		proxyConnectionErrors,
++		proxyReadErrors,
++		proxyWriteErrors,
++		proxyReadBytes,
++		proxyWriteBytes,
++		proxyConnectionDuration,
++	)
++}
++
 +type httpsProxyDialer string
 +
-+func (d httpsProxyDialer) DialContext(cxt context.Context, network, address string) (net.Conn, error) {
++type cleanupState struct {
++	closed    *atomic.Bool
++	startTime time.Time
++}
++
++type httpsProxyConn struct {
++	net.Conn
++
++	closed    atomic.Bool
++	startTime time.Time
++}
++
++func (c *httpsProxyConn) Close() error {
++	if c.closed.CompareAndSwap(false, true) {
++		activeProxyConnections.Dec()
++		proxyConnectionDuration.Observe(time.Since(c.startTime).Seconds())
++	}
++
++	return c.Conn.Close()
++}
++
++func (c *httpsProxyConn) Read(b []byte) (int, error) {
++	n, err := c.Conn.Read(b)
++	if n > 0 {
++		proxyReadBytes.Add(float64(n))
++	}
++	if err != nil && err != io.EOF && !errors.Is(err, net.ErrClosed) {
++		proxyReadErrors.Inc()
++	}
++	return n, err
++}
++
++func (c *httpsProxyConn) Write(b []byte) (int, error) {
++	n, err := c.Conn.Write(b)
++	if n > 0 {
++		proxyWriteBytes.Add(float64(n))
++	}
++	if err != nil && !errors.Is(err, net.ErrClosed) {
++		proxyWriteErrors.Inc()
++	}
++	return n, err
++}
++
++func (d httpsProxyDialer) DialContext(cxt context.Context, network, address string) (conn net.Conn, err error) {
++	defer func() {
++		if err != nil {
++			proxyConnectionErrors.Inc()
++			if conn != nil {
++				_ = conn.Close()
++				conn = nil
++			}
++		}
++	}()
++
 +	if network != "tcp" {
 +		return nil, errors.Errorf("unsupported network for proxy '%s', support tcp", network)
 +	}
@@ -39,7 +158,7 @@ index 1bbf59c3..6f1f317f 100644
 +		proxyHost = net.JoinHostPort(proxyHost, "80")
 +	}
 +	dialer := net.Dialer{}
-+	conn, err := dialer.DialContext(cxt, network, proxyHost)
++	conn, err = dialer.DialContext(cxt, network, proxyHost)
 +	if err != nil {
 +		return nil, fmt.Errorf("failed to dial proxy: %w", err)
 +	}
@@ -67,16 +186,32 @@ index 1bbf59c3..6f1f317f 100644
 +	}
 +	err = request.Write(conn)
 +	if err != nil {
-+		return nil, fmt.Errorf("failed to send CONNECT request to proxy: %w", err)
++		return conn, fmt.Errorf("failed to send CONNECT request to proxy: %w", err)
 +	}
 +	response, err := http.ReadResponse(bufio.NewReaderSize(conn, 0), &request)
 +	if err != nil {
-+		return nil, fmt.Errorf("failed to receive http CONNECT response from proxy: %w", err)
++		return conn, fmt.Errorf("failed to receive http CONNECT response from proxy: %w", err)
 +	}
++	defer response.Body.Close()
 +	if response.StatusCode != 200 {
-+		return nil, fmt.Errorf("proxy return %d response for CONNECT request", response.StatusCode)
++		return conn, fmt.Errorf("proxy return %d response for CONNECT request", response.StatusCode)
 +	}
-+	return conn, nil
++	_, err = io.Copy(io.Discard, response.Body)
++	if err != nil {
++		return conn, fmt.Errorf("failed to receive http CONNECT response body from proxy: %w", err)
++	}
++	activeProxyConnections.Inc()
++	proxyConn := &httpsProxyConn{
++		Conn:      conn,
++		startTime: time.Now(),
++	}
++	runtime.AddCleanup(proxyConn, func(state *cleanupState) {
++		if !state.closed.Load() {
++			activeProxyConnections.Dec()
++			proxyConnectionDuration.Observe(time.Since(state.startTime).Seconds())
++		}
++	}, &cleanupState{closed: &proxyConn.closed, startTime: proxyConn.startTime})
++	return proxyConn, nil
 +}
 +
 +func (d httpsProxyDialer) Dial(network, address string) (net.Conn, error) {
@@ -86,7 +221,7 @@ index 1bbf59c3..6f1f317f 100644
  // DialEdge makes a TLS connection to a Cloudflare edge node
  func DialEdge(
  	ctx context.Context,
-@@ -25,7 +94,31 @@ func DialEdge(
+@@ -25,7 +229,31 @@ func DialEdge(
  	if localIP != nil {
  		dialer.LocalAddr = &net.TCPAddr{IP: localIP, Port: 0}
  	}


### PR DESCRIPTION
Exposing Prometheus metrics about the HTTP proxy connection cloudflared uses to communicate with the Cloudflare edge servers. This will significantly help us debug network-related problems.